### PR TITLE
Reverting simple_mvn POM to use thrift-maven-plugin 0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 gen-*
 *.class
 a.out
+target/
 

--- a/part3/java/simple_mvn/pom.xml
+++ b/part3/java/simple_mvn/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>thrift-maven-plugin</artifactId>
-                <version>0.12.0</version>
+                <version>0.10.0</version>
                 <configuration>
                     <thriftExecutable>/usr/local/bin/thrift</thriftExecutable>
                 </configuration>


### PR DESCRIPTION
Running in master from within container `randyabernethi/thrift-book`
```
$ git checkout master
Switched to branch 'master'
$ mvn package
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Simple Apache Thrift Maven Project 1.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[WARNING] The POM for org.apache.thrift:thrift-maven-plugin:jar:0.12.0 is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.131 s
[INFO] Finished at: 2020-09-19T22:16:58+00:00
[INFO] Final Memory: 5M/192M
[INFO] ------------------------------------------------------------------------
[ERROR] Plugin org.apache.thrift:thrift-maven-plugin:0.12.0 or one of its dependencies could not be resolved: Failure to find org.apache.thrift:thrift-maven-plugin:jar:0.12.0 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException
```

Reverting to 0.10.0 solves the problem:

```
$ git checkout revert_simple_mvn_pom
Switched to branch 'revert_simple_mvn_pom'
$ mvn package
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Simple Apache Thrift Maven Project 1.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- thrift-maven-plugin:0.10.0:compile (thrift-sources) @ simple ---
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ simple ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/totoro/ThriftBook/part3/java/simple_mvn/src/main/resources
[INFO] Copying 1 resource
[INFO]
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ simple ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 3 source files to /home/totoro/ThriftBook/part3/java/simple_mvn/target/classes
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ simple ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/totoro/ThriftBook/part3/java/simple_mvn/src/test/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.3:testCompile (default-testCompile) @ simple ---
[INFO] No sources to compile
[INFO]
[INFO] --- maven-surefire-plugin:2.17:test (default-test) @ simple ---
[INFO] No tests to run.
[INFO]
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ simple ---
[INFO] Building jar: /home/totoro/ThriftBook/part3/java/simple_mvn/target/simple-1.0-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.053 s
[INFO] Finished at: 2020-09-19T22:18:06+00:00
[INFO] Final Memory: 17M/200M
[INFO] ------------------------------------------------------------------------

```