### PR TITLE
Minor fixes on listing 4.2

### DIFF
--- a/part2/transports/memory/mem_trans.py
+++ b/part2/transports/memory/mem_trans.py
@@ -4,16 +4,13 @@ import pickle
 from thrift.transport import TTransport
 
 class Trade:
-    def __init__(self):
-        symbol=""
-        price=0.0
-        size=0
+    def __init__(self, symbol="", price=0.0, size=0):
+        self.symbol=symbol
+        self.price=price
+        self.size=size
 
 trans = TTransport.TMemoryBuffer()
-trade = Trade()
-trade.symbol = "F"
-trade.price = 13.10
-trade.size = 2500
+trade = Trade("F", 13.10, 2500)
 trans.write(pickle.dumps(trade))
 
 trans.cstringio_buf.seek(0)


### PR DESCRIPTION
The instance variables in class Trade have method scope. The program still works because you add to the dictionary the variables after the call to the constructor. Can be tested in Idle:
```
>>> class Trade:
    def __init__(self):
        symbol=""
        price=0.0
        size=0

>>> t = Trade()
>>> dir(t)
['__doc__', '__init__', '__module__']
>>> t.__dict__
{}
```
If we now define the class like this:
```
>>> class Trade2:
    def __init__(self):
        self.symbol=""
        self.price=0.0
        self.size=0

        
>>> t = Trade2()
>>> t.__dict__
{'symbol': '', 'price': 0.0, 'size': 0}
>>> dir(t)
['__doc__', '__init__', '__module__', 'price', 'size', 'symbol']
>
```